### PR TITLE
feat: display complete attribute data with prominent IDs [sc-46130]

### DIFF
--- a/build/handlers/tool-handlers.js
+++ b/build/handlers/tool-handlers.js
@@ -78,7 +78,15 @@ export class ToolHandlers {
             // Store attributes in memory for resource access using ResourceManager
             this.resourceManager.addAttributesAsResources(response.records);
             // Format the response
-            const formattedResults = response.records.map(attr => `- ${attr.display_name} (${attr.name}): ${attr.description.substring(0, 100)}...`).join('\n');
+            const formattedResults = response.records.map(attr => {
+                // Include full description, with smart truncation only for extremely long descriptions
+                const description = attr.description.length > 500
+                    ? `${attr.description.substring(0, 497)}...`
+                    : attr.description;
+                return `- **${attr.display_name}** (ID: ${attr.id}, Name: ${attr.name})
+  Type: ${attr.type}
+  Description: ${description}`;
+            }).join('\n\n');
             return {
                 content: [
                     {

--- a/src/handlers/tool-handlers.ts
+++ b/src/handlers/tool-handlers.ts
@@ -120,9 +120,16 @@ export class ToolHandlers {
       this.resourceManager.addAttributesAsResources(response.records);
 
       // Format the response
-      const formattedResults = response.records.map(attr => 
-        `- ${attr.display_name} (${attr.name}): ${attr.description.substring(0, 100)}...`
-      ).join('\n');
+      const formattedResults = response.records.map(attr => {
+        // Include full description, with smart truncation only for extremely long descriptions
+        const description = attr.description.length > 500 
+          ? `${attr.description.substring(0, 497)}...` 
+          : attr.description;
+        
+        return `- **${attr.display_name}** (ID: ${attr.id}, Name: ${attr.name})
+  Type: ${attr.type}
+  Description: ${description}`;
+      }).join('\n\n');
 
       return {
         content: [


### PR DESCRIPTION
- Remove 100-character description truncation limit
- Display full attribute descriptions (smart truncation at 500 chars)
- Show attribute IDs prominently in formatted response
- Include attribute type and name metadata
- Improve readability with multi-line format and better spacing
- Maintain backward compatibility with resource access patterns

Resolves data discovery workflow friction by providing complete attribute information in search results without requiring individual resource lookups.